### PR TITLE
tolerate multiple versions of a DSC resource

### DIFF
--- a/Functions/classResourceInvokerType.Tests.ps1
+++ b/Functions/classResourceInvokerType.Tests.ps1
@@ -6,11 +6,11 @@ $records = @{}
 $stubResourceNames = @(
     'StubResource1AFriendlyName','StubResource1BFriendlyName',
     'StubResource2A','StubResource2B','StubResource2C',
-    'StubResource3A','StubResource3B'
+    'StubResource3A','StubResource3B','StubResource4A'
 )
 $stubClassResourceNames = @(
     'StubResource2A','StubResource2B','StubResource2C',
-    'StubResource3A','StubResource3B'
+    'StubResource3A','StubResource3B','StubResource4A'
 )
 $stubMofResourceNames = @(
     'StubResource1AFriendlyName','StubResource1BFriendlyName'
@@ -39,7 +39,7 @@ Describe New-ClassResourceObject {
     {
         $record = $records.$resourceName
         It "returns correct resource object for $resourceName" {
-            $r = $record.DscResource | New-ClassResourceObject
+            $r = $record.DscResource | Select -First 1 | New-ClassResourceObject
             $r.Count | Should be 1
             $r.GetType().Name | Should be $resourceName
         }
@@ -51,7 +51,7 @@ Describe Test-ClassResourceType {
     {
         $record = $records.$resourceName
         It "$resourceName is a Class resource type" {
-            $r = $record.DscResource | Test-ClassResourceType
+            $r = $record.DscResource | Select -First 1 | Test-ClassResourceType
             $r.Count | Should be 1
             $r | Should beOfType bool
             $r | Should be $true

--- a/Functions/classResourceInvokerType.ps1
+++ b/Functions/classResourceInvokerType.ps1
@@ -67,9 +67,17 @@ function New-ClassResourceObject
         )
         {
             $module | Import-Module
+
+            # $module isn't always a fully-populated object at this point
+            # We get the loaded modules(s) of the right name and select the
+            # one at the right path.
+            $liveModule = Get-Module $module.Name |
+                ? { $_.ModuleBase -eq $module.ModuleBase } |
+                Select -First 1
+
             try
             {
-                $object = (Get-Module $module.Name).NewBoundScriptBlock(
+                $object = $liveModule.NewBoundScriptBlock(
                     [scriptblock]::Create("[$($DscResource.Name)]::new()")
                 ).InvokeReturnAsIs()
             }

--- a/Functions/configDocumentType.ps1
+++ b/Functions/configDocumentType.ps1
@@ -88,12 +88,14 @@ function ConvertTo-ConfigDocument
         $resources = [System.Collections.Generic.Dictionary[System.String,Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]]::new()
         foreach ( $resource in $InputObject.DscResources )
         {
-            # check for duplicate resource names
-            if ( $resources.ContainsKey( $resource.Name ) )
+            # skip duplicate resources with lower version numbers
+            if
+            (
+                $resources.ContainsKey( $resource.Name ) -and
+                ( $resource.Version -lt $resources.($resource.Name).Version )
+            )
             {
-                throw [System.FormatException]::new(
-                    "Duplicate resource named $($resource.Name)"
-                )
+                continue
             }
 
             $resources.($resource.Name) = $resource


### PR DESCRIPTION
fix problem where Get-Module Name was returning multiple versions
change ConvertTo-ConfigDocument to bind to the latest encountered version of a DSC resource
resolve #33 